### PR TITLE
Wraps GetForm() in a try-catch block 

### DIFF
--- a/Umbraco.Courier.FormsProvider/FormItemProvider.cs
+++ b/Umbraco.Courier.FormsProvider/FormItemProvider.cs
@@ -159,7 +159,18 @@ namespace Umbraco.Courier.FormsProvider
         public override Item HandlePack(ItemIdentifier id)
         {
             var fs = new Umbraco.Forms.Data.Storage.FormStorage();
-            var form = fs.GetForm(Guid.Parse(id.Id));
+            Forms.Core.Form form;
+
+            try
+            {
+                // If there is no form on the target disk or cache this method raises a System.NullReferenceException
+                // See https://github.com/umbraco/Umbraco.Courier.FormsProvider/issues/3
+                form = fs.GetForm(Guid.Parse(id.Id));
+            }
+            catch (Exception ex)
+            {
+                return null;
+            }
 
             if(form == null)
                 return null;

--- a/Umbraco.Courier.FormsProvider/FormItemProvider.cs
+++ b/Umbraco.Courier.FormsProvider/FormItemProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Umbraco.Core;
@@ -161,6 +162,8 @@ namespace Umbraco.Courier.FormsProvider
             var fs = new Umbraco.Forms.Data.Storage.FormStorage();
             Forms.Core.Form form;
 
+            var formsDataLocation = GetFormsDataLocation();
+
             try
             {
                 // If there is no form on the target disk or cache this method raises a System.NullReferenceException
@@ -180,7 +183,7 @@ namespace Umbraco.Courier.FormsProvider
             item.Name = form.Name;
 
             //Handle forms and fields
-            var formPath = Umbraco.Forms.Core.Configuration.ContourFolder + "/data/forms/" + id.Id + ".json";
+            var formPath = formsDataLocation + "/forms/" + id.Id + ".json";
             item.Resources.Add(formPath);
 
             //handle submit to node id
@@ -202,7 +205,7 @@ namespace Umbraco.Courier.FormsProvider
                     if (prvParsed.Count > 0)
                         item.PrevalueSourceSettings.Add(field.PreValueSourceId , prvParsed);
 
-                    item.Resources.Add(Umbraco.Forms.Core.Configuration.ContourFolder + "/data/prevalueSources/" + field.PreValueSourceId + ".json");
+                    item.Resources.Add(formsDataLocation + "/prevalueSources/" + field.PreValueSourceId + ".json");
                 }
             }
 
@@ -224,7 +227,7 @@ namespace Umbraco.Courier.FormsProvider
                             item.DataSourceSettings = dsParsed;
 
                         //add as file to item
-                        item.Resources.Add(Umbraco.Forms.Core.Configuration.ContourFolder + "/data/datasources/" + form.DataSource.Id.ToString() + ".json");
+                        item.Resources.Add(formsDataLocation + "/datasources/" + form.DataSource.Id.ToString() + ".json");
                     }
                     
                 }
@@ -247,7 +250,7 @@ namespace Umbraco.Courier.FormsProvider
                                 item.WorkflowSettings.Add(wfId, wfParsed);
 
                             //add file to item 
-                            item.Resources.Add(Umbraco.Forms.Core.Configuration.ContourFolder + "/data/workflows/" + wfId.ToString() + ".json");
+                            item.Resources.Add(formsDataLocation + "/workflows/" + wfId.ToString() + ".json");
                         }
                     }    
                 }
@@ -325,6 +328,42 @@ namespace Umbraco.Courier.FormsProvider
             }
 
             return current;
+        }
+
+        private string GetFormsDataLocation()
+        {
+            //Forms V4 - stored JSON files at App_Plugins/UmbracoForms/Data
+            //Forms V6 - we have a Forms FileSystem Provider that abstract Files away but the default is at App_Data/UmbracoForms/Data
+
+            //Forms returns a string and not a Version object
+            var formsVersion = Version.Parse(Forms.Core.Configuration.Version);
+            var formsSix = new Version(6,0,0);
+
+            if (formsVersion >= formsSix)
+            {
+                //We will need to do reflection (yuk!)
+                //Forms has the following - Umbraco.Forms.Data.Storage.FormsFileSystem.Instance.IsDefaultFileSystem
+
+                var formsAssembly = Assembly.Load("Umbraco.Forms.Core");
+                Type t = formsAssembly.GetType("Umbraco.Forms.Data.Storage.FormsFileSystem");
+                var instanceProp = t.GetStaticProperty("Instance");
+               
+                var isDefaultFileSystemValue = instanceProp.GetPropertyValue("IsDefaultFileSystem");
+                bool isDefaultFileSystem = isDefaultFileSystemValue is bool && (bool)isDefaultFileSystemValue;
+
+                if (isDefaultFileSystem)
+                {
+                    //We know that in V6 it got moved to App_Data & only if has not be overwritten by a Forms FileSytem Provider
+                    return "~/App_Data/UmbracoForms/Data";
+                }
+
+                //Most likely using Azure File System Provider to store JSON in Blob Storage
+                //Will we support that workflow - as both environments could use share blob storage account?
+                throw new NotSupportedException("We are unable to Courier Forms that are not stored on disk at /App_Data/UmbracoForms/Data");
+            }
+            
+            //It's Forms 4 and was hardcoded to be stored at App_Plugins/UmbracoForms/Data
+            return "~/App_Plugins/UmbracoForms/Data";
         }
 
     }

--- a/Umbraco.Courier.FormsProvider/ReflectionUtility.cs
+++ b/Umbraco.Courier.FormsProvider/ReflectionUtility.cs
@@ -1,0 +1,418 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Umbraco.Courier.FormsProvider
+{
+    internal static class ReflectionUtility
+    {
+        private static Func<TInstance, TValue> GetPropertyGetter<TInstance, TValue>(PropertyInfo property)
+        {
+            var type = typeof(TInstance);
+
+            var getMethod = property.GetMethod;
+            if (getMethod == null)
+                throw new InvalidOperationException($"Property {type}.{property.Name} : {property.PropertyType} does not have a getter.");
+
+            var exprThis = Expression.Parameter(type, "this");
+            var exprCall = Expression.Call(exprThis, getMethod);
+            var expr = Expression.Lambda<Func<TInstance, TValue>>(exprCall, exprThis);
+            return expr.Compile();
+        }
+
+        private static Action<TInstance, TValue> GetPropertySetter<TInstance, TValue>(PropertyInfo property)
+        {
+            var type = typeof(TInstance);
+
+            var setMethod = property.SetMethod;
+            if (setMethod == null)
+                throw new InvalidOperationException($"Property {type}.{property.Name} : {property.PropertyType} does not have a setter.");
+
+            var exprThis = Expression.Parameter(type, "this");
+            var exprArg0 = Expression.Parameter(typeof(TValue), "value");
+            var exprCall = Expression.Call(exprThis, setMethod, exprArg0);
+            var expr = Expression.Lambda<Action<TInstance, TValue>>(exprCall, exprThis, exprArg0);
+            return expr.Compile();
+        }
+
+        public static Func<TInstance, TValue> GetPropertyGetter<TInstance, TValue>(string propertyName)
+        {
+            var type = typeof(TInstance);
+            var type0 = typeof(TValue);
+            var property = type.GetProperty(propertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (property == null || property.PropertyType != type0)
+                throw new InvalidOperationException($"Could not get property {type}.{propertyName} : {type0}.");
+            return GetPropertyGetter<TInstance, TValue>(property);
+        }
+
+        public static Action<TInstance, TValue> GetPropertySetter<TInstance, TValue>(string propertyName)
+        {
+            var type = typeof(TInstance);
+            var type0 = typeof(TValue);
+            var property = type.GetProperty(propertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (property == null || property.PropertyType != type0)
+                throw new InvalidOperationException($"Could not get property {type}.{propertyName} : {type0}.");
+            return GetPropertySetter<TInstance, TValue>(property);
+        }
+
+        public static void GetPropertyGetterSetter<TInstance, TValue>(string propertyName, out Func<TInstance, TValue> getter, out Action<TInstance, TValue> setter)
+        {
+            var type = typeof(TInstance);
+            var type0 = typeof(TValue);
+            var property = type.GetProperty(propertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (property == null || property.PropertyType != type0)
+                throw new InvalidOperationException($"Could not get property {type}.{propertyName} : {type0}.");
+            getter = GetPropertyGetter<TInstance, TValue>(property);
+            setter = GetPropertySetter<TInstance, TValue>(property);
+        }
+
+        public static Func<TInstance> GetCtor<TInstance>()
+        {
+            var type = typeof(TInstance);
+
+            // get the constructor infos
+            var ctor = type.GetConstructor(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance,
+                null, Type.EmptyTypes, null);
+
+            if (ctor == null)
+                throw new InvalidOperationException($"Could not find constructor {type}.ctor().");
+
+            var exprNew = Expression.New(ctor);
+            var expr = Expression.Lambda<Func<TInstance>>(exprNew);
+            return expr.Compile();
+        }
+
+        public static Func<TArg0, TInstance> GetCtor<TInstance, TArg0>()
+        {
+            var type = typeof(TInstance);
+            var type0 = typeof(TArg0);
+
+            // get the constructor infos
+            var ctor = type.GetConstructor(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance,
+                null, new[] { type0 }, null);
+
+            if (ctor == null)
+                throw new InvalidOperationException($"Could not find constructor {type}.ctor({type0}).");
+
+            var exprArgs = ctor.GetParameters().Select(x => Expression.Parameter(x.ParameterType, x.Name)).ToArray();
+            // ReSharper disable once CoVariantArrayConversion
+            var exprNew = Expression.New(ctor, exprArgs);
+            var expr = Expression.Lambda<Func<TArg0, TInstance>>(exprNew, exprArgs);
+            return expr.Compile();
+        }
+
+        public static Func<TArg0, TArg1, TInstance> GetCtor<TInstance, TArg0, TArg1>()
+        {
+            var type = typeof(TInstance);
+            var type0 = typeof(TArg0);
+            var type1 = typeof(TArg1);
+
+            // get the constructor infos
+            var ctor = type.GetConstructor(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance,
+                null, new[] { type0, type1 }, null);
+
+            if (ctor == null)
+                throw new InvalidOperationException($"Could not find constructor {type}.ctor({type0}, {type1}).");
+
+            var exprArgs = ctor.GetParameters().Select(x => Expression.Parameter(x.ParameterType, x.Name)).ToArray();
+            // ReSharper disable once CoVariantArrayConversion
+            var exprNew = Expression.New(ctor, exprArgs);
+            var expr = Expression.Lambda<Func<TArg0, TArg1, TInstance>>(exprNew, exprArgs);
+            return expr.Compile();
+        }
+
+        public static TMethod GetMethod<TMethod>(MethodInfo method)
+        {
+            var type = method.DeclaringType;
+
+            GetMethodParms<TMethod>(out var parameterTypes, out var returnType);
+            return GetStaticMethod<TMethod>(method, method.Name, type, parameterTypes, returnType);
+        }
+
+        public static TMethod GetMethod<TInstance, TMethod>(MethodInfo method)
+        {
+            var type = method.DeclaringType;
+
+            GetMethodParms<TInstance, TMethod>(out var parameterTypes, out var returnType);
+            return GetMethod<TMethod>(method, method.Name, type, parameterTypes, returnType);
+        }
+
+        public static TMethod GetMethod<TInstance, TMethod>(string methodName)
+        {
+            var type = typeof(TInstance);
+
+            GetMethodParms<TInstance, TMethod>(out var parameterTypes, out var returnType);
+
+            var method = type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance,
+                null, parameterTypes, null);
+
+            return GetMethod<TMethod>(method, methodName, type, parameterTypes, returnType);
+        }
+
+        private static void GetMethodParms<TMethod>(out Type[] parameterTypes, out Type returnType)
+        {
+            var typeM = typeof(TMethod);
+            var typeList = new List<Type>();
+            returnType = typeof(void);
+
+            if (!typeof(MulticastDelegate).IsAssignableFrom(typeM) || typeM == typeof(MulticastDelegate))
+                throw new InvalidOperationException("Invalid TMethod, must be a Func or Action.");
+
+            var typeName = typeM.FullName;
+            if (typeName.StartsWith("System.Func`"))
+            {
+                var i = 0;
+                while (i < typeM.GenericTypeArguments.Length - 1)
+                    typeList.Add(typeM.GenericTypeArguments[i++]);
+                returnType = typeM.GenericTypeArguments[i];
+            }
+            else if (typeName.StartsWith("System.Action`"))
+            {
+                var i = 0;
+                while (i < typeM.GenericTypeArguments.Length)
+                    typeList.Add(typeM.GenericTypeArguments[i++]);
+            }
+            else if (typeName == "System.Action")
+            {
+                // no args
+            }
+            else
+                throw new InvalidOperationException(typeName);
+
+            parameterTypes = typeList.ToArray();
+        }
+
+        private static void GetMethodParms<TInstance, TMethod>(out Type[] parameterTypes, out Type returnType)
+        {
+            var type = typeof(TInstance);
+
+            var typeM = typeof(TMethod);
+            var typeList = new List<Type>();
+            returnType = typeof(void);
+
+            if (!typeof(MulticastDelegate).IsAssignableFrom(typeM) || typeM == typeof(MulticastDelegate))
+                throw new InvalidOperationException("Invalid TMethod, must be a Func or Action.");
+
+            var typeName = typeM.FullName;
+            if (!typeM.IsGenericType)
+                throw new InvalidOperationException(typeName);
+            if (typeM.GenericTypeArguments[0] != type)
+                throw new InvalidOperationException("Invalid TMethod, the first generic argument must be TInstance.");
+            if (typeName.StartsWith("System.Func`"))
+            {
+                var i = 1;
+                while (i < typeM.GenericTypeArguments.Length - 1)
+                    typeList.Add(typeM.GenericTypeArguments[i++]);
+                returnType = typeM.GenericTypeArguments[i];
+            }
+            else if (typeName.StartsWith("System.Action`"))
+            {
+                var i = 1;
+                while (i < typeM.GenericTypeArguments.Length)
+                    typeList.Add(typeM.GenericTypeArguments[i++]);
+            }
+            else
+                throw new InvalidOperationException(typeName);
+
+            parameterTypes = typeList.ToArray();
+        }
+
+        private static TMethod GetStaticMethod<TMethod>(MethodInfo method, string methodName, Type type, Type[] parameterTypes, Type returnType)
+        {
+            if (method == null || method.ReturnType != returnType)
+                throw new InvalidOperationException($"Could not find static method {type}.{methodName}({string.Join(",", parameterTypes.Select(x => x.ToString()))}) : {returnType}");
+
+            var e = new List<ParameterExpression>();
+            foreach (var p in method.GetParameters())
+                e.Add(Expression.Parameter(p.ParameterType, p.Name));
+            var exprCallArgs = e.ToArray();
+            var exprLambdaArgs = exprCallArgs;
+
+            // ReSharper disable once CoVariantArrayConversion
+            var exprCall = Expression.Call(method, exprCallArgs);
+            var expr = Expression.Lambda<TMethod>(exprCall, exprLambdaArgs);
+            return expr.Compile();
+        }
+
+        private static TMethod GetMethod<TMethod>(MethodInfo method, string methodName, Type type, Type[] parameterTypes, Type returnType)
+        {
+            if (method == null || method.ReturnType != returnType)
+                throw new InvalidOperationException($"Could not find method {type}.{methodName}({string.Join(",", parameterTypes.Select(x => x.ToString()))}) : {returnType}");
+
+            var e = new List<ParameterExpression>();
+            foreach (var p in method.GetParameters())
+                e.Add(Expression.Parameter(p.ParameterType, p.Name));
+            var exprCallArgs = e.ToArray();
+
+            var exprThis = Expression.Parameter(type, "this");
+            e.Insert(0, exprThis);
+            var exprLambdaArgs = e.ToArray();
+
+            // ReSharper disable once CoVariantArrayConversion
+            var exprCall = Expression.Call(exprThis, method, exprCallArgs);
+            var expr = Expression.Lambda<TMethod>(exprCall, exprLambdaArgs);
+            return expr.Compile();
+        }
+
+        public static object GetStaticProperty(this Type type, string propertyName, Func<IEnumerable<PropertyInfo>, PropertyInfo> filter = null)
+        {
+            var propertyInfo = GetPropertyInfo(type, propertyName, filter);
+            if (propertyInfo == null)
+                throw new ArgumentOutOfRangeException(nameof(propertyName),
+                    $"Couldn't find property {propertyName} in type {type.FullName}");
+            return propertyInfo.GetValue(null, null);
+        }
+
+        public static object CallStaticMethod(this Type type, string methodName, params object[] parameters)
+        {
+            var methodInfo = GetMethodInfo(type, methodName);
+            if (methodInfo == null)
+                throw new ArgumentOutOfRangeException(nameof(methodName),
+                    $"Couldn't find method {methodName} in type {type.FullName}");
+            return methodInfo.Invoke(null, parameters);
+        }
+
+        public static object CallMethod(this object obj, string methodName, params object[] parameters)
+        {
+            if (obj == null)
+                throw new ArgumentNullException(nameof(obj));
+            Type type = obj.GetType();
+            var methodInfo = GetMethodInfo(type, methodName);
+            if (methodInfo == null)
+                throw new ArgumentOutOfRangeException(nameof(methodName),
+                    $"Couldn't find method {methodName} in type {type.FullName}");
+            return methodInfo.Invoke(obj, parameters);
+        }
+
+        public static object CallMethod(this object obj, string methodName, Func<IEnumerable<MethodInfo>, MethodInfo> filter = null, params object[] parameters)
+        {
+            if (obj == null)
+                throw new ArgumentNullException(nameof(obj));
+            Type type = obj.GetType();
+            var methodInfo = GetMethodInfo(type, methodName, filter);
+            if (methodInfo == null)
+                throw new ArgumentOutOfRangeException(nameof(methodName),
+                    $"Couldn't find method {methodName} in type {type.FullName}");
+            return methodInfo.Invoke(obj, parameters);
+        }
+
+        private static MethodInfo GetMethodInfo(Type type, string methodName, Func<IEnumerable<MethodInfo>, MethodInfo> filter = null)
+        {
+            MethodInfo methodInfo;
+            do
+            {
+                try
+                {
+                    methodInfo = type.GetMethod(methodName,
+                        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+                }
+                catch (AmbiguousMatchException)
+                {
+                    if (filter == null) throw;
+
+                    methodInfo = filter(
+                        type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                            .Where(x => x.Name == methodName));
+                }
+                type = type.BaseType;
+            }
+            while (methodInfo == null && type != null);
+            return methodInfo;
+        }
+
+        private static PropertyInfo GetPropertyInfo(Type type, string propertyName, Func<IEnumerable<PropertyInfo>, PropertyInfo> filter = null)
+        {
+            PropertyInfo propInfo;
+            do
+            {
+                try
+                {
+                    propInfo = type.GetProperty(propertyName,
+                        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+                }
+                catch (AmbiguousMatchException)
+                {
+                    if (filter == null) throw;
+
+                    propInfo = filter(type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                        .Where(x => x.Name == propertyName));
+                }
+                type = type.BaseType;
+            }
+            while (propInfo == null && type != null);
+            return propInfo;
+        }
+
+        public static object GetPropertyValue(this object obj, string propertyName)
+        {
+            if (obj == null)
+                throw new ArgumentNullException(nameof(obj));
+            Type objType = obj.GetType();
+            PropertyInfo propInfo = GetPropertyInfo(objType, propertyName);
+            if (propInfo == null)
+                throw new ArgumentOutOfRangeException(nameof(propertyName),
+                    $"Couldn't find property {propertyName} in type {objType.FullName}");
+            return propInfo.GetValue(obj, null);
+        }
+
+        public static object GetPropertyValue(this object obj, string propertyName, IDictionary<string, PropertyInfo> propCache)
+        {
+            if (obj == null)
+                throw new ArgumentNullException(nameof(obj));
+            Type objType = obj.GetType();
+            PropertyInfo propInfo;
+            if (propCache.ContainsKey(propertyName))
+            {
+                propInfo = propCache[propertyName];
+            }
+            else
+            {
+                propInfo = GetPropertyInfo(objType, propertyName);
+                if (propInfo == null)
+                    throw new ArgumentOutOfRangeException(nameof(propertyName),
+                        $"Couldn't find property {propertyName} in type {objType.FullName}");
+
+                propCache[propertyName] = propInfo;
+            }
+            return propInfo.GetValue(obj, null);
+        }
+
+        public static void SetPropertyValue(this object obj, string propertyName, object val)
+        {
+            if (obj == null)
+                throw new ArgumentNullException(nameof(obj));
+            Type objType = obj.GetType();
+            PropertyInfo propInfo = GetPropertyInfo(objType, propertyName);
+            if (propInfo == null)
+                throw new ArgumentOutOfRangeException(nameof(propertyName),
+                    $"Couldn't find property {propertyName} in type {objType.FullName}");
+            propInfo.SetValue(obj, val, null);
+        }
+
+        public static void SetPropertyValue(this object obj, string propertyName, object val, IDictionary<string, PropertyInfo> propCache)
+        {
+            if (obj == null) throw new ArgumentNullException(nameof(obj));
+            if (propCache == null) throw new ArgumentNullException(nameof(propCache));
+
+            Type objType = obj.GetType();
+            PropertyInfo propInfo;
+            if (propCache.ContainsKey(propertyName))
+            {
+                propInfo = propCache[propertyName];
+            }
+            else
+            {
+                propInfo = GetPropertyInfo(objType, propertyName);
+                if (propInfo == null)
+                    throw new ArgumentOutOfRangeException(nameof(propertyName),
+                        $"Couldn't find property {propertyName} in type {objType.FullName}");
+
+                propCache[propertyName] = propInfo;
+            }
+
+            propInfo.SetValue(obj, val, null);
+        }
+    }
+}

--- a/Umbraco.Courier.FormsProvider/Umbraco.Courier.FormsProvider.csproj
+++ b/Umbraco.Courier.FormsProvider/Umbraco.Courier.FormsProvider.csproj
@@ -62,6 +62,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\xmlrpcnet.2.5.0\lib\net20\CookComputing.XmlRpcV2.dll</HintPath>
     </Reference>
+    <Reference Include="EPPlus, Version=4.0.5.0, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoForms.Core.4.4.5\lib\EPPlus.dll</HintPath>
+    </Reference>
     <Reference Include="Examine, Version=0.1.52.2941, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\UmbracoCms.Core.7.0.0\lib\Examine.dll</HintPath>
@@ -234,21 +237,20 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\UmbracoCms.Core.7.0.0\lib\umbraco.editorControls.dll</HintPath>
     </Reference>
-    <Reference Include="Umbraco.Forms.Core, Version=4.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoForms.Core.4.1.0\lib\Umbraco.Forms.Core.dll</HintPath>
+    <Reference Include="Umbraco.Forms.Core, Version=4.4.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoForms.Core.4.4.5\lib\Umbraco.Forms.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Umbraco.Forms.Core.Providers">
-      <HintPath>..\packages\UmbracoForms.Core.4.1.0\lib\Umbraco.Forms.Core.Providers.dll</HintPath>
+    <Reference Include="Umbraco.Forms.Core.Providers, Version=4.4.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoForms.Core.4.4.5\lib\Umbraco.Forms.Core.Providers.dll</HintPath>
     </Reference>
-    <Reference Include="Umbraco.Forms.Web">
-      <HintPath>..\packages\UmbracoForms.Core.4.1.0\lib\Umbraco.Forms.Web.dll</HintPath>
+    <Reference Include="Umbraco.Forms.Web, Version=4.4.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoForms.Core.4.4.5\lib\Umbraco.Forms.Web.dll</HintPath>
     </Reference>
-    <Reference Include="Umbraco.Forms.Web.XmlSerializers">
-      <HintPath>..\packages\UmbracoForms.Core.4.1.0\lib\Umbraco.Forms.Web.XmlSerializers.dll</HintPath>
+    <Reference Include="Umbraco.Forms.Web.XmlSerializers, Version=4.4.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoForms.Core.4.4.5\lib\Umbraco.Forms.Web.XmlSerializers.dll</HintPath>
     </Reference>
-    <Reference Include="Umbraco.Licensing">
-      <HintPath>..\packages\Courier.Core.3.1.4\lib\Umbraco.Licensing.dll</HintPath>
+    <Reference Include="Umbraco.Licensing, Version=2.0.33.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoForms.Core.4.4.5\lib\Umbraco.Licensing.dll</HintPath>
     </Reference>
     <Reference Include="umbraco.MacroEngines, Version=1.0.5073.23301, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -281,6 +283,7 @@
     <Compile Include="FormMacroResolver.cs" />
     <Compile Include="FormPickerResolver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReflectionUtility.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Umbraco.Courier.FormsProvider/app.config
+++ b/Umbraco.Courier.FormsProvider/app.config
@@ -22,6 +22,10 @@
         <assemblyIdentity name="System.Web.WebPages.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.4.0.0" newVersion="3.4.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Umbraco.Courier.FormsProvider/packages.config
+++ b/Umbraco.Courier.FormsProvider/packages.config
@@ -4,6 +4,7 @@
   <package id="ClientDependency" version="1.8.0.0" targetFramework="net45" />
   <package id="ClientDependency-Mvc" version="1.8.0.0" targetFramework="net45" />
   <package id="Courier.Core" version="3.1.4" targetFramework="net45" />
+  <package id="EPPlus" version="4.0.5" targetFramework="net45" />
   <package id="Examine" version="0.1.57.2941" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.6" targetFramework="net45" />
   <package id="ImageProcessor" version="1.9.5.0" targetFramework="net45" />
@@ -24,6 +25,6 @@
   <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="UmbracoCms.Core" version="7.0.0" targetFramework="net45" />
-  <package id="UmbracoForms.Core" version="4.1.0" targetFramework="net45" />
+  <package id="UmbracoForms.Core" version="4.4.5" targetFramework="net45" />
   <package id="xmlrpcnet" version="2.5.0" targetFramework="net45" />
 </packages>

--- a/Umbraco.Courier.FormsTreeProvider/app.config
+++ b/Umbraco.Courier.FormsTreeProvider/app.config
@@ -22,6 +22,10 @@
         <assemblyIdentity name="System.Web.WebPages.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.4.0.0" newVersion="3.4.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
so we can return null in the event of a NullReferenceException.  This occurs when attempting to deploy a new form that does not yet exist on the target.

Fixes https://github.com/umbraco/Umbraco.Courier.FormsProvider/issues/3